### PR TITLE
pip install -r requirements.txt breaks at pkg-resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django==2.2.4
-pkg-resources==0.0.0
 psycopg2-binary==2.8.3
 pytz==2019.2
 sqlparse==0.3.0


### PR DESCRIPTION
After a quick search, this seems to be a recurring issue and it's safe to remove `pkg-resources==0.0.0` from the code without causing any harm
https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command