### PR TITLE
Issue 40 | Changed the size of filter bar and map

### DIFF
--- a/seismic_site/map_app/static/css/map.css
+++ b/seismic_site/map_app/static/css/map.css
@@ -4,6 +4,9 @@
     padding: 0;
 }
 
+#content {
+    padding: 5% 0;
+}
 
 /* General */
 
@@ -86,7 +89,7 @@
 
 /* RS bar */
 
-.active {
+.active, .navbar-category .active:hover {
     background-color: black;
 }
 
@@ -96,6 +99,10 @@
 
 .navbar-category {
     background-color: #EE741B;
+}
+
+.navbar-category li:hover {
+    background-color: #D66718;
 }
 
 .navbar-category a {

--- a/seismic_site/map_app/templates/map.html
+++ b/seismic_site/map_app/templates/map.html
@@ -9,14 +9,14 @@
     <button class="navbar-toggler" data-target="#navbarNav" data-toggle="collapse" type="button">
         <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="collapse navbar-collapse navbar-category" id="navbarNav">
+    <div class="collapse navbar-collapse navbar-category justify-content-lg-center" id="navbarNav">
         <ul class="navbar-nav">
-            <li class="filter-button" id="all">
+            <li class="filter-button pl-sm-2 px-lg-0" id="all">
                 <a class="nav-link" href="#">Toate clădirile cu risc seismic</a>
             </li>
 
             {% for category in used_categories %}
-                <li class="filter-button" id="{{ category }}">
+                <li class="filter-button pl-sm-2 px-lg-0" id="{{ category }}">
                     <a class="nav-link" href="#">
                         Clasa {{ category }} de risc seismic
                     </a>


### PR DESCRIPTION
Fixes #40 

map.html
* centered the filter bar for large devices
* adjusted the padding for the filter bar items

map.css
* removed the horizontal padding for the content
* added darker shade hover effect for the filter bar

![image](https://user-images.githubusercontent.com/22684808/69212853-17fbb700-0b6b-11ea-9e03-5aff629208c8.png)

I tried reproducing the behavior of the filter bar but with no success. The filter bar is always visible: full size for large devices up, and collapsed for medium devices down. Can you give more details about this ?