### PR TITLE
Initial Django Rest Framework set up

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tablib==0.13.0
 django-jet==1.0.8
 django-crispy-forms>=1.7.2,<2.0.0
 django-ckeditor>=5.7
+djangorestframework~=3.10.3

--- a/seismic_site/map_app/serializers.py
+++ b/seismic_site/map_app/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import Building
+
+
+class BuildingSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Building
+        fields = '__all__'  # TODO: restrict to the necessary fields

--- a/seismic_site/map_app/views.py
+++ b/seismic_site/map_app/views.py
@@ -1,3 +1,10 @@
 from django.shortcuts import render
+from rest_framework import viewsets
 
-# Create your views here.
+from .models import Building
+from .serializers import BuildingSerializer
+
+
+class BuildingViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Building.objects.all()
+    serializer_class = BuildingSerializer

--- a/seismic_site/seismic_site/settings.py
+++ b/seismic_site/seismic_site/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'cms.apps.CmsConfig',
     'seismic_site.apps.SeismicSiteConfig',
     'api.apps.ApiConfig',
@@ -139,3 +140,11 @@ STATICFILES_DIRS = (
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 CRISPY_FAIL_SILENTLY = not DEBUG
+
+REST_FRAMEWORK = {
+    # Use Django's standard `django.contrib.auth` permissions,
+    # or allow read-only access for unauthenticated users.
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+    ]
+}

--- a/seismic_site/seismic_site/urls.py
+++ b/seismic_site/seismic_site/urls.py
@@ -15,15 +15,20 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-
-from . import views
-
+from rest_framework.routers import DefaultRouter
 from django.conf import settings
 from django.conf.urls.static import static
 
+from . import views
+from map_app.views import BuildingViewSet
+
+router = DefaultRouter()
+router.register(r'buildings', BuildingViewSet)
+
 
 urlpatterns = [
-    path('api/', include('api.urls')),
+    path('api/v1/', include('api.urls')),  # This is the legacy API
+    path('api/v2/', include(router.urls)),
     path('jet/', include('jet.urls', 'jet')),
     path('admin/', admin.site.urls),
     path('account/', include('account.urls')),


### PR DESCRIPTION
Issue #58 

The new API is located at http://localhost:8000/newapi/ in order to keep the old API at /api/ (for now).