### PR TITLE
Format all the code from ./api with Black

### DIFF
--- a/api/account/apps.py
+++ b/api/account/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class AccountConfig(AppConfig):
-    name = 'account'
+    name = "account"

--- a/api/account/forms.py
+++ b/api/account/forms.py
@@ -2,13 +2,10 @@ from django import forms
 
 
 class LoginForm(forms.Form):
-
     def __init__(self, *args, **kwargs):
         super(LoginForm, self).__init__(*args, **kwargs)
-        self.fields['username'].label = "Utilizator"
-        self.fields['password'].label = "Parolă"
-
+        self.fields["username"].label = "Utilizator"
+        self.fields["password"].label = "Parolă"
 
     username = forms.CharField()
     password = forms.CharField(widget=forms.PasswordInput)
-

--- a/api/account/urls.py
+++ b/api/account/urls.py
@@ -3,6 +3,6 @@ from . import views
 
 urlpatterns = [
     # post views
-    path('login/', views.user_login, name='login'),
-    path('logout/', views.user_logout, name='logout')
+    path("login/", views.user_login, name="login"),
+    path("logout/", views.user_logout, name="logout"),
 ]

--- a/api/account/views.py
+++ b/api/account/views.py
@@ -6,27 +6,27 @@ from .forms import LoginForm
 
 
 def user_login(request):
-    if request.method == 'POST':
+    if request.method == "POST":
         form = LoginForm(request.POST)
         if form.is_valid():
             cd = form.cleaned_data
-            user = authenticate(request,
-                                username=cd['username'],
-                                password=cd['password'])
+            user = authenticate(
+                request, username=cd["username"], password=cd["password"]
+            )
             if user is not None:
                 if user.is_active:
                     login(request, user)
-                    return redirect('index')
+                    return redirect("index")
                     # return HttpResponse('Authenticated successfully')
                 else:
-                    return HttpResponse('Disabled account')
+                    return HttpResponse("Disabled account")
             else:
-                return HttpResponse('Invalid login')
+                return HttpResponse("Invalid login")
     else:
         form = LoginForm()
-    return render(request, 'account/login.html', {'form': form})
+    return render(request, "account/login.html", {"form": form})
 
 
 def user_logout(request):
     logout(request)
-    return redirect('index')
+    return redirect("index")

--- a/api/buildings/apps.py
+++ b/api/buildings/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class BuildingsConfig(AppConfig):
-    name = 'buildings'
+    name = "buildings"

--- a/api/buildings/router.py
+++ b/api/buildings/router.py
@@ -5,8 +5,4 @@ from buildings import views
 
 router = routers.DefaultRouter()
 
-router.register(
-    r'buildings',
-    views.BuildingViewSet,
-    basename='buildings'
-)
+router.register(r"buildings", views.BuildingViewSet, basename="buildings")

--- a/api/buildings/views.py
+++ b/api/buildings/views.py
@@ -7,6 +7,7 @@ class BuildingViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows buildings to be viewed or edited.
     """
+
     queryset = Building.objects.all().order_by("-created_on")
     serializer_class = BuildingSerializer
     lookup_field = "general_id"

--- a/api/cms/admin.py
+++ b/api/cms/admin.py
@@ -5,7 +5,7 @@ from .models import Page, Category, Attachment
 
 @admin.register(Category)
 class CategoryAdmin(admin.ModelAdmin):
-    list_display = ('name', )
+    list_display = ("name",)
 
 
 class DocumentInline(admin.TabularInline):
@@ -14,9 +14,7 @@ class DocumentInline(admin.TabularInline):
 
 @admin.register(Page)
 class PageAdmin(admin.ModelAdmin):
-    list_display = ('title', 'category', 'updated_on', 'is_published')
-    list_filter = ('is_published', )
+    list_display = ("title", "category", "updated_on", "is_published")
+    list_filter = ("is_published",)
     # prepopulated_fields = {"slug": ("title",)}
-    inlines = [
-        DocumentInline,
-    ]
+    inlines = [DocumentInline]

--- a/api/cms/apps.py
+++ b/api/cms/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class CmsConfig(AppConfig):
-    name = 'cms'
+    name = "cms"

--- a/api/cms/models.py
+++ b/api/cms/models.py
@@ -6,7 +6,8 @@ from django.utils.text import slugify
 
 class Category(models.Model):
     name = models.CharField(
-        blank=False, null=False, max_length=150, unique=True)
+        blank=False, null=False, max_length=150, unique=True
+    )
 
     def __str__(self):
         return "{}".format(self.name)
@@ -17,25 +18,35 @@ class Category(models.Model):
 
 class Page(models.Model):
     category = models.ForeignKey(
-        Category, blank=True, null=True, on_delete=models.SET_NULL,
-        help_text="Page category")
-    title = models.CharField(
-        blank=True, max_length=150,
-        help_text="Page title")
+        Category,
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+        help_text="Page category",
+    )
+    title = models.CharField(blank=True, max_length=150, help_text="Page title")
     slug = models.SlugField(
-        unique=True, blank=True, null=False,
-        help_text="Unique URL slug (leave empty to auto-generate)")
+        unique=True,
+        blank=True,
+        null=False,
+        help_text="Unique URL slug (leave empty to auto-generate)",
+    )
     content = RichTextField()
     updated_on = models.DateTimeField(
         auto_now=timezone.now,
-        blank=True, null=True, editable=False,
-        help_text="Last update time")
+        blank=True,
+        null=True,
+        editable=False,
+        help_text="Last update time",
+    )
     publishing_date = models.DateTimeField(
-        blank=True, null=True,
-        help_text="Public page publishing date")
+        blank=True, null=True, help_text="Public page publishing date"
+    )
     is_published = models.BooleanField(
-        default=False, db_index=True,
-        help_text="Is this page visible on the website")
+        default=False,
+        db_index=True,
+        help_text="Is this page visible on the website",
+    )
 
     def __str__(self):
         return "{}".format(self.title)
@@ -62,21 +73,22 @@ class Page(models.Model):
 
 class Attachment(models.Model):
     page = models.ForeignKey(
-        Page, blank=True, null=False, on_delete=models.CASCADE,
-        help_text="Page attachment")
-    name = models.CharField(
-        max_length=150,
-        help_text="Attachment name")
+        Page,
+        blank=True,
+        null=False,
+        on_delete=models.CASCADE,
+        help_text="Page attachment",
+    )
+    name = models.CharField(max_length=150, help_text="Attachment name")
     upload_date = models.DateTimeField(
-        auto_now=timezone.now,
-        help_text="Attachment upload date")
+        auto_now=timezone.now, help_text="Attachment upload date"
+    )
     uploaded_file = models.FileField(
-        upload_to='uploads/%Y/%m/%d/', max_length=100)
+        upload_to="uploads/%Y/%m/%d/", max_length=100
+    )
 
     def __str__(self):
-        return "{}{}".format(
-            self.uploaded_file.url,
-            self.name)
+        return "{}{}".format(self.uploaded_file.url, self.name)
 
 
 # class InlineResource(models.Model):

--- a/api/cms/router.py
+++ b/api/cms/router.py
@@ -5,8 +5,4 @@ from cms import views
 
 router = routers.DefaultRouter()
 
-router.register(
-    r'pages',
-    views.PagesViewSet,
-    basename='pages'
-)
+router.register(r"pages", views.PagesViewSet, basename="pages")

--- a/api/cms/urls.py
+++ b/api/cms/urls.py
@@ -3,6 +3,4 @@ from django.urls import path
 from . import views
 
 
-urlpatterns = [
-    path('<slug:slug>/', views.view_page, name='view_page')
-]
+urlpatterns = [path("<slug:slug>/", views.view_page, name="view_page")]

--- a/api/cms/views.py
+++ b/api/cms/views.py
@@ -7,17 +7,14 @@ from .models import Page
 
 def view_page(request, slug):
     page = get_object_or_404(Page, slug=slug, is_published=True)
-    return render(
-        request,
-        'cms/view_page.html', {
-            'page': page
-        })
+    return render(request, "cms/view_page.html", {"page": page})
 
 
 class PagesViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows buildings to be viewed or edited.
     """
+
     queryset = Page.objects.all().order_by("-publishing_date")
     serializer_class = PageSerializer
     lookup_field = "slug"

--- a/api/manage.py
+++ b/api/manage.py
@@ -5,8 +5,8 @@ import sys
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'seismic_site.settings')
-    os.environ.setdefault('DJANGO_CONFIGURATION', 'Prod')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "seismic_site.settings")
+    os.environ.setdefault("DJANGO_CONFIGURATION", "Prod")
     try:
         from configurations.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +18,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/api/map_app/apps.py
+++ b/api/map_app/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class MapAppConfig(AppConfig):
-    name = 'map_app'
+    name = "map_app"

--- a/api/seismic_site/apps.py
+++ b/api/seismic_site/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class SeismicSiteConfig(AppConfig):
-    name = 'seismic_site'
+    name = "seismic_site"

--- a/api/seismic_site/settings.py
+++ b/api/seismic_site/settings.py
@@ -25,89 +25,84 @@ class Base(Configuration):
     ALLOWED_HOSTS = []
 
     INSTALLED_APPS = [
-        'account',
-        'jet',
+        "account",
+        "jet",
         # django apps
-        'django.contrib.admin',
-        'django.contrib.auth',
-        'django.contrib.contenttypes',
-        'django.contrib.sessions',
-        'django.contrib.messages',
-        'django.contrib.staticfiles',
+        "django.contrib.admin",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.sessions",
+        "django.contrib.messages",
+        "django.contrib.staticfiles",
         # third-party apps
-        'rest_framework',
-        'crispy_forms',
-        'ckeditor',
+        "rest_framework",
+        "crispy_forms",
+        "ckeditor",
         # project apps
-        'cms.apps.CmsConfig',
-        'map_app',
-        'buildings',
+        "cms.apps.CmsConfig",
+        "map_app",
+        "buildings",
     ]
 
     MIDDLEWARE = [
-        'django.middleware.security.SecurityMiddleware',
-        'whitenoise.middleware.WhiteNoiseMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        "django.middleware.security.SecurityMiddleware",
+        "whitenoise.middleware.WhiteNoiseMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.common.CommonMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ]
 
-    ROOT_URLCONF = 'seismic_site.urls'
+    ROOT_URLCONF = "seismic_site.urls"
 
     TEMPLATES = [
         {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [
-                'seismic_site/templates',
-                'templates'
-            ],
-            'APP_DIRS': True,
-            'OPTIONS': {
-                'context_processors': [
-                    'django.template.context_processors.debug',
-                    'django.template.context_processors.request',
-                    'django.contrib.auth.context_processors.auth',
-                    'django.contrib.messages.context_processors.messages',
-                ],
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": ["seismic_site/templates", "templates"],
+            "APP_DIRS": True,
+            "OPTIONS": {
+                "context_processors": [
+                    "django.template.context_processors.debug",
+                    "django.template.context_processors.request",
+                    "django.contrib.auth.context_processors.auth",
+                    "django.contrib.messages.context_processors.messages",
+                ]
             },
-        },
+        }
     ]
 
-    WSGI_APPLICATION = 'seismic_site.wsgi.application'
+    WSGI_APPLICATION = "seismic_site.wsgi.application"
 
     # Database
     # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-    DATABASES = {
-        'default': dj_database_url.config(conn_max_age=600)
-    }
+    DATABASES = {"default": dj_database_url.config(conn_max_age=600)}
 
     # Password validation
     # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 
     AUTH_PASSWORD_VALIDATORS = [
         {
-            'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+            "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
         },
         {
-            'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+            "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"
         },
         {
-            'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+            "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"
         },
         {
-            'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+            "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"
         },
     ]
 
     # Internationalization
     # https://docs.djangoproject.com/en/2.2/topics/i18n/
 
-    LANGUAGE_CODE = values.Value(default='en-us')
-    TIME_ZONE = 'UTC'
+    LANGUAGE_CODE = values.Value(default="en-us")
+    TIME_ZONE = "UTC"
     USE_I18N = True
     USE_L10N = True
     USE_TZ = True
@@ -115,35 +110,35 @@ class Base(Configuration):
     # Static files (CSS, JavaScript, Images)
     # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
-    STATIC_URL = '/static/'
-    STATIC_ROOT = os.path.join(BASE_DIR, '../public/static')
-    STATICFILES_DIRS = (
-        os.path.join(BASE_DIR, 'static'),
+    STATIC_URL = "/static/"
+    STATIC_ROOT = os.path.join(BASE_DIR, "../public/static")
+    STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
+    STATICFILES_STORAGE = (
+        "whitenoise.storage.CompressedManifestStaticFilesStorage"
     )
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-    MEDIA_URL = '/media/'
-    MEDIA_ROOT = os.path.join(BASE_DIR, '../public/media')
+    MEDIA_URL = "/media/"
+    MEDIA_ROOT = os.path.join(BASE_DIR, "../public/media")
 
-    CRISPY_TEMPLATE_PACK = 'bootstrap4'
+    CRISPY_TEMPLATE_PACK = "bootstrap4"
     CRISPY_FAIL_SILENTLY = not DEBUG
 
     REST_FRAMEWORK = {
         # Use Django's standard `django.contrib.auth` permissions,
         # or allow read-only access for unauthenticated users.
-        'DEFAULT_PERMISSION_CLASSES': [
-            'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+        "DEFAULT_PERMISSION_CLASSES": [
+            "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"
         ]
     }
 
 
 class Dev(Base):
     DEBUG = True
-    SECRET_KEY = 'secret'
+    SECRET_KEY = "secret"
 
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 
 class Prod(Base):
     DEBUG = False
-    ALLOWED_HOSTS = values.ListValue(default=['.code4.ro'])
+    ALLOWED_HOSTS = values.ListValue(default=[".code4.ro"])

--- a/api/seismic_site/urls.py
+++ b/api/seismic_site/urls.py
@@ -25,16 +25,15 @@ from django.conf.urls.static import static
 
 urlpatterns = [
     # API
-    path('api/v2/', include(('buildings.urls', 'buildings'), namespace='buildings-api')),
-    path('api/v2/', include(cms_router.urls)),
-
-    path('jet/', include('jet.urls', 'jet')),
-    path('admin/', admin.site.urls),
-    path('account/', include('account.urls')),
-    path('page/', include('cms.urls')),
-    path('adauga', views.add_building, name="add-building"),
-    path('', views.index, name="index"),
-] + static(
-    settings.MEDIA_URL,
-    document_root=settings.MEDIA_ROOT,
-)
+    path(
+        "api/v2/",
+        include(("buildings.urls", "buildings"), namespace="buildings-api"),
+    ),
+    path("api/v2/", include(cms_router.urls)),
+    path("jet/", include("jet.urls", "jet")),
+    path("admin/", admin.site.urls),
+    path("account/", include("account.urls")),
+    path("page/", include("cms.urls")),
+    path("adauga", views.add_building, name="add-building"),
+    path("", views.index, name="index"),
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/api/seismic_site/wsgi.py
+++ b/api/seismic_site/wsgi.py
@@ -9,8 +9,8 @@ https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/
 
 import os
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'seismic_site.settings')
-os.environ.setdefault('DJANGO_CONFIGURATION', 'Prod')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "seismic_site.settings")
+os.environ.setdefault("DJANGO_CONFIGURATION", "Prod")
 
 from configurations.wsgi import get_wsgi_application  # noqa
 

--- a/api/wait_for_db.py
+++ b/api/wait_for_db.py
@@ -14,15 +14,15 @@ logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     db_config = dj_database_url.config()
 
     config = {
-        'dbname': db_config['NAME'],
-        'user': db_config['USER'],
-        'password': db_config['PASSWORD'],
-        'host': db_config['HOST'],
-        'port': db_config['PORT'],
+        "dbname": db_config["NAME"],
+        "user": db_config["USER"],
+        "password": db_config["PASSWORD"],
+        "host": db_config["HOST"],
+        "port": db_config["PORT"],
     }
 
     start_time = time()
@@ -30,11 +30,11 @@ if __name__ == '__main__':
     while time() - start_time < timeout:
         try:
             conn = psycopg2.connect(**config)
-            logger.info('DB ready! 🎉')
+            logger.info("DB ready! 🎉")
             conn.close()
             sys.exit()
         except psycopg2.OperationalError:
-            logger.info(f'DB not ready. Waiting for 1 second ...')
+            logger.info(f"DB not ready. Waiting for 1 second ...")
             sleep(1)
 
-    logger.error(f'Could not connect to DB within {timeout} seconds.')
+    logger.error(f"Could not connect to DB within {timeout} seconds.")


### PR DESCRIPTION
Please don't take any of these changes personal (e.g. how to place brackets, `"` instead of `'` etc.).
This should be the standard going forward and a checker is in place to make sure the code is compatible with these changes.

Make your code "Black" with:
`black --line-length 80 --target-version py37 --exclude migrations ./api`
(you can install black using `pip`)

- line length: 80
- target version: Python 3.7