### PR TITLE
Change format checker to exclude checking migrations

### DIFF
--- a/.github/workflows/check-format-black.yml
+++ b/.github/workflows/check-format-black.yml
@@ -19,4 +19,4 @@ jobs:
         pip install black
     - name: Check formatting with black
       run: |
-        black --line-length 80 --target-version py37 --check ./api
+        black --line-length 80 --target-version py37 --exclude migrations --check ./api


### PR DESCRIPTION
Related to #49
add the --exclude option to avoid checking migrations files