### PR TITLE
Change format checker to only run on Python files

### DIFF
--- a/.github/workflows/check-format-black.yml
+++ b/.github/workflows/check-format-black.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '**.py'
 
 jobs:
   build:


### PR DESCRIPTION
The checker would run on any push, including for JS files.
Only run on modifications of Python files since only they are relevant.