### PR TITLE
Error on unsupported Ubuntu version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install-docker-ubuntu:
 	sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
 	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 	sudo apt-key fingerprint 0EBFCD88
-	sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(shell lsb_release -cs) stable"
+	sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(shell lsb_release -cs) stable" || { echo "$(shell lsb_release -cs) is not yet supported by docker.com."; exit 1; }
 	sudo apt-get update
 	sudo apt-get install -y docker-ce
 	sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(shell uname -s)-$(shell uname -m)" -o /usr/local/bin/docker-compose


### PR DESCRIPTION
Fixes #102 .

There are two ways to address this, that I see:
1. Work-around: hard-code an Ubuntu version to use in case `add-apt-repository` fails.
2. Halt with an error if `add-apt-repository` fails.

Option number 1 will become deprecated when the current Ubuntu version becomes supported by Docker. The work-around will require maintenance. 

So I went with option 2. 