### PR TITLE
Remove dependabot python configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,15 +12,3 @@ update_configs:
     default_labels:
       - "dependencies"
       - "react"
-  # - package_manager: "python"
-  #   directory: "api/"
-  #   update_schedule: "live"
-  #   target_branch: "master"
-  #   default_reviewers:
-  #     - "tudoramariei"
-  #     - "catileptic"
-  #   default_assignees:
-  #     - "tudoramariei"
-  #   default_labels:
-  #     - "dependencies"
-  #     - "django"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,17 +1,5 @@
 version: 1
 update_configs:
-  - package_manager: "python"
-    directory: "api/"
-    update_schedule: "live"
-    target_branch: "master"
-    default_reviewers:
-      - "tudoramariei"
-      - "catileptic"
-    default_assignees:
-      - "tudoramariei"
-    default_labels:
-      - "dependencies"
-      - "django"
   - package_manager: "javascript"
     directory: "client/"
     update_schedule: "live"
@@ -24,3 +12,15 @@ update_configs:
     default_labels:
       - "dependencies"
       - "react"
+  # - package_manager: "python"
+  #   directory: "api/"
+  #   update_schedule: "live"
+  #   target_branch: "master"
+  #   default_reviewers:
+  #     - "tudoramariei"
+  #     - "catileptic"
+  #   default_assignees:
+  #     - "tudoramariei"
+  #   default_labels:
+  #     - "dependencies"
+  #     - "django"


### PR DESCRIPTION
Looking at PRs like #188 and #190 it seems that @dependabot isn't properly managing Python dependencies using pip-compile. Right now it's removing packages which wouldn't be removed with a normal `make upgrade-requirements` which can cause some big problems in the long run.