### PR TITLE
Added Map API Key to Environment

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -3,3 +3,4 @@ DJANGO_CONFIGURATION=Dev
 DATABASE_URL=postgres://postgres@db:5432/postgres
 # client
 NODE_ENV=development
+REACT_APP_API_KEY=

--- a/client/src/components/HereMap.js
+++ b/client/src/components/HereMap.js
@@ -5,7 +5,7 @@ import React from 'react';
 
 const baseUrl = 'https://image.maps.ls.hereapi.com/mia/1.6/mapview';
 const mapConfig = {
-  // apiKey: "API_KEY_HERE",
+  apiKey: process.env.REACT_APP_API_KEY,
   w: 1000,
   h: 300,
   // zoom level

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - api
     environment:
       NODE_ENV:
+      REACT_APP_API_KEY:
 
   api:
     container_name: seismic-risc-api


### PR DESCRIPTION
Closes #151 

- added `REACT_APP_API_KEY` to `docker-compose`
- added the variable to `.env.dist`, makefile will copy this file to `.env`
- added the variable to `HereMap.js` - `process.env.REACT_APP_API_KEY`

Not sure about this solution