### PR TITLE
Fix Social Media images and footer text

### DIFF
--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -10,31 +10,11 @@ function subscribe(e) {
 }
 
 const Footer = () => {
-  const [textStyle, setTextStyle] = React.useState({
-    textAlign: window.innerWidth > 768 ? 'start' : 'center',
-  });
-
-  const updateWidth = () => {
-    const width = window.innerWidth;
-    if (width < 768) {
-      textStyle.textAlign = 'center';
-      setTextStyle(textStyle);
-    } else {
-      textStyle.textAlign = 'start';
-      setTextStyle(textStyle);
-    }
-  };
-
-  React.useEffect(() => {
-    window.addEventListener('resize', updateWidth);
-    return () => window.removeEventListener('resize', updateWidth);
-  });
-
   return (
     <div className="App-footer">
       <div className="footer-inside">
         <Row type="flex" justify="space-between" gutter={[0, 40]}>
-          <Col md={8} xs={24} style={textStyle}>
+          <Col md={8} xs={24}>
             <Title level={4}>Link-uri utile</Title>
             <Row>
               <a href="/termeni-si-conditii">
@@ -66,7 +46,7 @@ const Footer = () => {
           <Col md={8} xs={24} justify="space-between">
             <Row gutter={[0, 40]}>
               <Col>
-                <Row style={textStyle}>
+                <Row>
                   <Title level={4} strong>
                     Abonează-te la newsletter
                   </Title>
@@ -80,7 +60,7 @@ const Footer = () => {
               </Col>
               <Col>
                 <Row>
-                  <Col style={textStyle}>
+                  <Col>
                     <Text level={4}>
                       © 2019 Code for Romania.
                       <br />

--- a/client/src/components/SocialBar/SocialBar.js
+++ b/client/src/components/SocialBar/SocialBar.js
@@ -1,32 +1,26 @@
 import React from 'react';
-import { Row, Col } from 'antd';
 import facebookLogo from '../../images/facebook_grey.png';
 import instagramLogo from '../../images/instagram_grey.png';
 import linkedinLogo from '../../images/linkedin_grey.png';
 import twitterLogo from '../../images/twitter_grey.png';
-
-const socialBarStyle = {
-  backgroundColor: '#F0F0F0',
-  maxHeight: '60px',
-};
 
 const donateLinkStyle = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   color: '#fff',
-  fontFamily: 'Titillium Web',
   fontStyle: 'normal',
   fontWeight: '600',
   fontSize: '24px',
-  height: '60px',
+  height: '64px',
   background: 'rgba(31, 185, 74, 0.7)',
   borderRadius: '3px',
   textDecoration: 'none',
   textTransform: 'uppercase',
-  marginLeft: '2px',
+  margin: '0 2px',
   borderTopRightRadius: '0',
   borderBottomRightRadius: '0',
+  padding: '0 5px',
 };
 
 const socialImageStyle = {
@@ -37,65 +31,60 @@ const socialImageStyle = {
 const socialLinkStyle = {
   marginLeft: '2px',
   display: 'inline-flex',
-  height: '60px',
+  height: '64px',
+  width: '64px',
+};
+
+const flexRow = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  maxHeight: '64px',
 };
 
 const SocialBar = () => {
   return (
-    <div style={socialBarStyle}>
-      <Row type="flex" justify="end">
-        <Col md={1} sm={2} xs={3}>
-          <a
-            style={socialLinkStyle}
-            href="https://www.facebook.com/code4romania"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src={facebookLogo} style={socialImageStyle} alt="Facebook" />
-          </a>
-        </Col>
-        <Col md={1} sm={2} xs={3}>
-          <a
-            style={socialLinkStyle}
-            href="https://www.instagram.com/code4romania"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src={instagramLogo} style={socialImageStyle} alt="Instagram" />
-          </a>
-        </Col>
-        <Col md={1} sm={2} xs={3}>
-          <a
-            style={socialLinkStyle}
-            href="https://www.linkedin.com/company/code4romania"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src={linkedinLogo} style={socialImageStyle} alt="LinkedIn" />
-          </a>
-        </Col>
-        <Col md={1} sm={2} xs={3}>
-          <a
-            style={socialLinkStyle}
-            href="https://twitter.com/Code4Romania"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src={twitterLogo} style={socialImageStyle} alt="Twitter" />
-          </a>
-        </Col>
+    <div style={flexRow}>
+      <a
+        style={socialLinkStyle}
+        href="https://www.facebook.com/code4romania"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img src={facebookLogo} style={socialImageStyle} alt="Facebook" />
+      </a>
+      <a
+        style={socialLinkStyle}
+        href="https://www.instagram.com/code4romania"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img src={instagramLogo} style={socialImageStyle} alt="Instagram" />
+      </a>
+      <a
+        style={socialLinkStyle}
+        href="https://www.linkedin.com/company/code4romania"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img src={linkedinLogo} style={socialImageStyle} alt="LinkedIn" />
+      </a>
+      <a
+        style={socialLinkStyle}
+        href="https://twitter.com/Code4Romania"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <img src={twitterLogo} style={socialImageStyle} alt="Twitter" />
+      </a>
 
-        <Col md={4} sm={4} xs={12}>
-          <a
-            style={donateLinkStyle}
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://code4.ro/ro/doneaza/"
-          >
-            DONEAZĂ
-          </a>
-        </Col>
-      </Row>
+      <a
+        style={donateLinkStyle}
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://code4.ro/ro/doneaza/"
+      >
+        DONEAZĂ
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
Fix: #289 
Fix: #288 
What I find it curious about #288 is that the behavior was added intentionally, was there any specification in the design to be like this?

After: 
<img width="538" alt="Screenshot 2020-05-23 at 13 26 14" src="https://user-images.githubusercontent.com/23296075/82728536-89264d80-9cf9-11ea-8e61-167aa2cb640b.png">
<img width="1379" alt="Screenshot 2020-05-23 at 13 26 26" src="https://user-images.githubusercontent.com/23296075/82728535-888db700-9cf9-11ea-8078-d8330d4e28f5.png">


