### PR TITLE
Change dependabot update schedule to weekly

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,11 +2,10 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "client/"
-    update_schedule: "live"
+    update_schedule: "weekly"
     target_branch: "develop"
     default_reviewers:
       - "tudoramariei"
-      - "catileptic"
     default_assignees:
       - "tudoramariei"
     default_labels:


### PR DESCRIPTION
- updates appear too often and can become overwhelming 
- schedule should now be to run weekly on Tuesdays 
- reference: https://dependabot.com/docs/config-file 
