### PR TITLE
Issues 290 & 291 | Fix header

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@lingui/react": "^2.9.1",
+    "@ant-design/icons": "^4.2.1",
     "@lingui/macro": "^2.9.1",
+    "@lingui/react": "^2.9.1",
     "antd": "^3.26.12",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -11,26 +11,6 @@
   padding: 0;
 }
 
-.App-logo {
-  float: left;
-  padding-right: 32px;
-}
-
-.App-menu {
-  line-height: 64px;
-}
-
-.App-header {
-  background-color: #fff;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
 .App-link {
   color: #09d3ac;
 }

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,64 +1,58 @@
 import React, { useState } from 'react';
-import { Layout, Menu, Button } from 'antd';
+import { NavLink, Link } from 'react-router-dom';
+import { Layout, Button } from 'antd';
+import { MenuOutlined } from '@ant-design/icons';
 import { Trans } from '@lingui/macro';
 import logo from '../logo.svg';
-import styles from './header.module.css';
 
 const { Header } = Layout;
 
 export default ({ currentLanguage, languageChangeCallback }) => {
   const [langText, setLangText] = useState('English');
+  const [showMenu, setShowMenu] = useState(false);
+
+  const handleMenuClick = () => {
+    setShowMenu(!showMenu);
+  };
 
   return (
-    <Header style={{ background: 'none' }}>
+    <Header className={showMenu ? 'overlay' : ''}>
       <div className="App-logo">
-        <img src={logo} alt="Seismic Risc logo" />
+        <Link to="/">
+          <img src={logo} alt="Seismic Risc logo" />
+        </Link>
       </div>
-      <Menu
-        style={{ float: 'right' }}
-        theme="light"
-        mode="horizontal"
-        className="App-menu"
-        selectable={false}
+      <ul className={`App-menu ${showMenu ? 'show' : ''}`}>
+        <li>
+          <NavLink to="/" activeClassName="active">
+            <Trans>About</Trans>
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to="/contact" activeClassName="active">
+            <Trans>Contact us</Trans>
+          </NavLink>
+        </li>
+      </ul>
+      <div
+        className="languageChangeButton"
+        role="button"
+        onClick={() => {
+          if (currentLanguage === 'en') {
+            languageChangeCallback('ro');
+            setLangText('English');
+          } else {
+            languageChangeCallback('en');
+            setLangText('Romană');
+          }
+        }}
       >
-        <Menu.Item key="about">
-          <Trans>About</Trans>
-        </Menu.Item>
-        <Menu.Item key="guide">
-          <Trans>Homeowners associations guide</Trans>
-        </Menu.Item>
-        <Menu.Item key="legislation">
-          <Trans>Legislation</Trans>
-        </Menu.Item>
-        <Menu.Item key="bucharest">
-          <Trans>Vulnerable Bucharest</Trans>
-        </Menu.Item>
-        <Menu.Item key="contact">
-          <Trans>Contact us</Trans>
-        </Menu.Item>
-        <Menu.Item key="add">
-          <Button type="primary" icon="plus-circle" size="large">
-            <Trans>Add a building</Trans>
-          </Button>
-        </Menu.Item>
-        <Menu.Item key="lang">
-          <div
-            className={styles.languageChangeButton}
-            role="button"
-            onClick={() => {
-              if (currentLanguage === 'en') {
-                languageChangeCallback('ro');
-                setLangText('English');
-              } else {
-                languageChangeCallback('en');
-                setLangText('Romană');
-              }
-            }}
-          >
-            {langText}
-          </div>
-        </Menu.Item>
-      </Menu>
+        {langText}
+      </div>
+      <Button className="App-menu-button" onClick={handleMenuClick}>
+        <MenuOutlined />
+      </Button>
+      <div className={`overlay ${showMenu ? 'show' : ''}`} onClick={handleMenuClick} />
     </Header>
   );
 };

--- a/client/src/components/header.module.css
+++ b/client/src/components/header.module.css
@@ -1,3 +1,0 @@
-.languageChangeButton {
-  user-select: none;
-}

--- a/client/src/styles/_header.scss
+++ b/client/src/styles/_header.scss
@@ -1,0 +1,110 @@
+@use 'variables';
+
+.languageChangeButton {
+  user-select: none;
+}
+
+.languageChangeButton,
+.App-menu > li > a {
+  cursor: pointer;
+  transition: color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+  &:hover,
+  &:focus {
+    color: $primary-color !important;
+  }
+}
+
+.App-logo {
+  margin-right: auto;
+}
+
+.App-menu {
+  list-style-type: none;
+  text-align: center;
+  display: flex;
+  margin-bottom: 0;
+
+  @media (max-width: $breakpoint-tablet) {
+    background-color: #fff;
+    display: initial;
+    max-height: 0;
+    overflow: hidden;
+    position: absolute;
+    left: 0;
+    top: $header-height;
+    width: 100%;
+    z-index: 100;
+    padding: 0;
+    transition: max-height 0.3s ease;
+    line-height: 48px;
+
+    &.show {
+      max-height: 500px;
+    }
+  }
+
+  li > a {
+    color: unset !important;
+    display: inline-block;
+    padding: 0 1.5rem;
+    width: 100%;
+
+    &.active {
+      color: $primary-color !important;
+    }
+
+    @media (min-width: $breakpoint-tablet) {
+      border-bottom: 2px solid transparent;
+      transition: border-color 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+      &:hover {
+        border-bottom: 2px solid $primary-color;
+      }
+      &.active {
+        border-bottom: 2px solid $primary-color;
+      }
+    }
+  }
+}
+
+.ant-layout-header {
+  background-color: #fff;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  @media (max-width: $breakpoint-tablet) {
+    position: fixed;
+    left: 0;
+    width: 100%;
+    z-index: 5;
+    & div.overlay {
+      opacity: 0;
+      position: fixed;
+      left: 0;
+      background-color: rgba(0, 0, 0, 0.7);
+      &.show {
+        width: 100%;
+        top: $header-height;
+        bottom: 0;
+        height: 100%;
+        opacity: 1;
+        z-index: 10;
+      }
+    }
+  }
+}
+
+.App-menu-button {
+  margin-left: 1rem;
+  display: none;
+
+  @media (max-width: $breakpoint-tablet) {
+    display: initial;
+  }
+}
+
+.ant-layout-content {
+  @media (max-width: $breakpoint-tablet) {
+    margin-top: $header-height;
+  }
+}

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -1,0 +1,16 @@
+// =======================
+// breakpoints
+// =======================
+$breakpoint-desktop: 991px;
+$breakpoint-tablet: 767px;
+$breakpoint-mobile: 575px;
+
+// =======================
+// header
+// =======================
+$header-height: 64px;
+
+// =======================
+// colors
+// =======================
+$primary-color: #ee741b;

--- a/client/src/styles/theme.scss
+++ b/client/src/styles/theme.scss
@@ -1,4 +1,6 @@
+@import 'variables';
 @import 'blog';
 @import 'footer';
 @import 'building.details';
 @import 'map';
+@import 'header';


### PR DESCRIPTION
Fixes #290, #291 

Changed the header nodes to make use of the antd `Menu` components default behavior. Now for smaller devices the overflowed `Menu.Items` are shown in a sub-menu. This also fixes the problem with the menu overlapping with the description.

![header](https://i.gyazo.com/80eae10629fb2b487b4831a6464cb85f.gif)