### PR TITLE
Create API endpoint for the statistics

### DIFF
--- a/client/src/containers/home/StatisticFragment.js
+++ b/client/src/containers/home/StatisticFragment.js
@@ -10,17 +10,37 @@ const StatisticCard = (props) => (
   </Card>
 );
 
+const STATISTICS_URL = '/api/v1/statistics';
+
 export default () => {
+  const [state, setState] = React.useState({
+    peopleUnderRisk: '',
+    evaluatedBuildings: '',
+    consolidatedBuilding: '',
+  });
+  React.useEffect(() => {
+    fetch(STATISTICS_URL)
+      .then((res) => res.json())
+      .then(({ people_under_risk, evaluated_buildings, consolidated_buildings }) => {
+        setState((prevState) => ({
+          ...prevState,
+          peopleUnderRisk: people_under_risk,
+          evaluatedBuildings: evaluated_buildings,
+          consolidatedBuilding: consolidated_buildings,
+        }));
+      });
+  }, []);
+
   return (
     <Row gutter={[8, 32]} type="flex" justify="space-around" style={{ margin: '2rem' }}>
       <Col span={8}>
-        <StatisticCard value={6121} text="oameni sub risc" />
+        <StatisticCard value={state.peopleUnderRisk} text="oameni sub risc" />
       </Col>
       <Col span={8}>
-        <StatisticCard value={458} text="clădiri evaluate" />
+        <StatisticCard value={state.evaluatedBuildings} text="clădiri evaluate" />
       </Col>
       <Col span={8}>
-        <StatisticCard value={84} text="clădiri consolidate" />
+        <StatisticCard value={state.consolidatedBuilding} text="clădiri consolidate" />
       </Col>
     </Row>
   );

--- a/client/src/containers/home/StatisticFragment.js
+++ b/client/src/containers/home/StatisticFragment.js
@@ -21,12 +21,12 @@ export default () => {
   React.useEffect(() => {
     fetch(STATISTICS_URL)
       .then((res) => res.json())
-      .then(({ people_under_risk, evaluated_buildings, consolidated_buildings }) => {
+      .then(({ peopleUnderRisk, evaluatedBuildings, consolidatedBuildings }) => {
         setState((prevState) => ({
           ...prevState,
-          peopleUnderRisk: people_under_risk,
-          evaluatedBuildings: evaluated_buildings,
-          consolidatedBuilding: consolidated_buildings,
+          peopleUnderRisk,
+          evaluatedBuildings,
+          consolidatedBuildings,
         }));
       });
   }, []);


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?

[Make use of the API to get buildings statistics](https://github.com/code4romania/seismic-risc/issues/344)

Closes #344 

Retrieves statistics data from api on home page.

### How has it been tested?

I've tested it locally,

`STATISTICS_URL` constant might be changed.
