### PR TITLE
Refactor the way the URL is built

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,10 +1,10 @@
 const HOST_URL = process.env.REACT_APP_DJANGO_SITE_URL;
-const PORT = process.env.REACT_APP_DJANGO_PORT;
+const PORT = process.env.REACT_APP_DJANGO_PORT ? `:${process.env.REACT_APP_DJANGO_PORT}` : '';
 const API = process.env.REACT_APP_DJANGO_API_ENDPOINT;
 
 export default {
-  BUILDINGS_URL: `${HOST_URL}:${PORT}${API}buildings`,
-  PAGES_URL: `${HOST_URL}:${PORT}${API}pages`,
-  POSTS_URL: `${HOST_URL}:${PORT}${API}posts`,
+  BUILDINGS_URL: `${HOST_URL}${PORT}/${API}/buildings`,
+  PAGES_URL: `${HOST_URL}${PORT}/${API}/pages`,
+  POSTS_URL: `${HOST_URL}${PORT}/${API}/posts`,
   MAP_API_KEY: process.env.REACT_APP_API_KEY,
 };


### PR DESCRIPTION
The port can be optional. Making sure it and its `:` won't appear if the port doesn't exist. 