### PR TITLE
Have CORS whitelist use ALLOWED_HOSTS

### DIFF
--- a/api/seismic_site/settings.py
+++ b/api/seismic_site/settings.py
@@ -28,6 +28,7 @@ class Base(Configuration):
     SECRET_KEY = values.Value()
 
     ALLOWED_HOSTS = []
+    CORS_ORIGIN_ALLOW_ALL = False
     SITE_URL = values.Value()
     SITE_ID = 1
 
@@ -179,6 +180,7 @@ class Test(Base):
 class Prod(Base):
     DEBUG = False
     ALLOWED_HOSTS = values.ListValue(default=[".code4.ro"])
+    CORS_ORIGIN_WHITELIST = set(ALLOWED_HOSTS)
 
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
     EMAIL_USE_TLS = True


### PR DESCRIPTION
- use the values from ALLOWED_HOSTS for CORS whitelisting
