### PR TITLE
Fix naming in codeql files

### DIFF
--- a/.github/workflows/codeql-analysis-js.yml
+++ b/.github/workflows/codeql-analysis-js.yml
@@ -16,7 +16,7 @@ on:
     - cron: '0 7 * * 2'
 
 jobs:
-  analyze_py:
+  analyze_js:
     name: Analyze code
     runs-on: ubuntu-latest
 

--- a/.github/workflows/codeql-analysis-py.yml
+++ b/.github/workflows/codeql-analysis-py.yml
@@ -16,7 +16,7 @@ on:
     - cron: '15 7 * * 2'
 
 jobs:
-  analyze_js:
+  analyze_py:
     name: Analyze code
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- the job running the js check was called analyze_py and vice-versa

<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
This:
![Screenshot 2021-01-30 at 17 01 26](https://user-images.githubusercontent.com/2820084/106359673-ccbb6780-631c-11eb-9844-955c1f95871d.png)
