### PR TITLE
Improve guide page UX

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16785,9 +16785,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -18070,6 +18070,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "request-promise-core": {

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@lingui/macro": "^3.3.0",
     "@lingui/react": "^2.9.2",
     "antd": "^3.26.12",
+    "qs": "^6.9.6",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-pdf": "^5.1.0",

--- a/client/src/containers/guide/PdfViewer.js
+++ b/client/src/containers/guide/PdfViewer.js
@@ -1,6 +1,6 @@
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useEffect } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
-import { Row, Col, Button } from 'antd';
+import { Row, Button } from 'antd';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
@@ -26,43 +26,65 @@ const useWindowSize = () => {
 const MAX_PDF_PAGE_WIDTH = 500;
 
 // Based on https://github.com/wojtekmaj/react-pdf/wiki/Recipes#display-single-page-with-navigation
-const PdfViewer = ({ file }) => {
+const PdfViewer = ({ file, defaultPageNumber = 1 }) => {
   const windowSize = useWindowSize();
   const pageWidth = Math.min(MAX_PDF_PAGE_WIDTH, windowSize.width);
 
   const [numPages, setNumPages] = useState(null);
-  const [pageNumber, setPageNumber] = useState(1);
+  const [pageNumber, setPageNumber] = useState(defaultPageNumber);
 
   const handleLoadSuccess = (pdf) => {
     setNumPages(pdf.numPages);
-    setPageNumber(1);
   };
 
   const changePage = (offset) => setPageNumber((num) => num + offset);
   const previousPage = () => changePage(-1);
   const nextPage = () => changePage(+1);
 
+  const handleKeyDown = (e) => {
+    switch (e.key) {
+      case 'ArrowLeft':
+        if (pageNumber > 1) {
+          previousPage();
+        }
+        break;
+      case 'ArrowRight':
+        if (pageNumber < numPages) {
+          nextPage();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  });
+
   return (
     <>
-      <Document file={file} onLoadSuccess={handleLoadSuccess}>
-        <Page pageNumber={pageNumber} width={pageWidth} />
-      </Document>
+      <div style={{ width: pageWidth, minHeight: pageWidth * 1.5 }}>
+        <Document file={file} onLoadSuccess={handleLoadSuccess}>
+          <Page pageNumber={pageNumber} width={pageWidth} />
+        </Document>
+      </div>
       {numPages && (
         <>
           <p style={{ textAlign: 'center' }}>
             Pagina {pageNumber} din {numPages}
           </p>
           <Row type="flex" justify="center">
-            <Col span={8}>
-              <Button disabled={pageNumber <= 1} onClick={previousPage}>
-                Pagina anterioară
-              </Button>
-            </Col>
-            <Col span={8}>
-              <Button type="Primary" disabled={pageNumber >= numPages} onClick={nextPage}>
-                Pagina următoare
-              </Button>
-            </Col>
+            <Button disabled={pageNumber <= 1} onClick={previousPage} style={{ marginRight: 16 }}>
+              Pagina anterioară
+            </Button>
+            <Button type="Primary" disabled={pageNumber >= numPages} onClick={nextPage}>
+              Pagina următoare
+            </Button>
           </Row>
         </>
       )}

--- a/client/src/containers/guide/index.js
+++ b/client/src/containers/guide/index.js
@@ -1,11 +1,19 @@
 import React from 'react';
-import { Row, Col } from 'antd';
+import { useLocation } from 'react-router-dom';
+import qs from 'qs';
+import { Row, Col, Button } from 'antd';
 import Layout from '../../components/Layout';
 import PdfViewer from './PdfViewer';
 
 const GUIDE_PDF_URL = '/assets/documents/Toolkit Asociatii de proprietari v2018.pdf';
 
 const Guide = () => {
+  const { search } = useLocation();
+  const { page } = qs.parse(search, { ignoreQueryPrefix: true });
+  let pageNumber = parseInt(page, 10);
+  if (Number.isNaN(pageNumber)) {
+    pageNumber = 1;
+  }
   return (
     <Layout>
       <div className="page">
@@ -17,8 +25,13 @@ const Guide = () => {
           style={{ marginTop: '2rem', marginBottom: '2rem' }}
         >
           <Col>
-            <PdfViewer file={GUIDE_PDF_URL} />
+            <PdfViewer file={GUIDE_PDF_URL} defaultPageNumber={pageNumber} />
           </Col>
+        </Row>
+        <Row type="flex" justify="center">
+          <Button type="primary" icon="download" href={GUIDE_PDF_URL} download>
+            Descarcă
+          </Button>
         </Row>
       </div>
     </Layout>


### PR DESCRIPTION
### What does it fix?

- Fixes bug which made the web page scroll to the top when going to the next page in the PDF
- Adds document download button
- Adds navigation with keyboard arrows
- Allows setting the initial page with the `?page=<number>` query string. E.g. `/ghid?page=5`

### How has it been tested?

Every change has been tested locally to work.