### PR TITLE
Resolve warnings with pipeline files

### DIFF
--- a/.github/workflows/api_pipeline.yml
+++ b/.github/workflows/api_pipeline.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   static_analysis:
+    name: Run black formatting check
     runs-on: ubuntu-18.04
     steps:
     - name: Check out Git repository
@@ -34,6 +35,7 @@ jobs:
         black --line-length 80 --target-version py37 --exclude migrations --check ./api
 
   tests:
+    name: Run api tests
     runs-on: ubuntu-18.04
     steps:
     - name: Check out Git repository

--- a/.github/workflows/codeql-analysis-js.yml
+++ b/.github/workflows/codeql-analysis-js.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   analyze_js:
     name: Analyze code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -30,9 +30,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 2
-
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/codeql-analysis-py.yml
+++ b/.github/workflows/codeql-analysis-py.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   analyze_py:
     name: Analyze code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -30,9 +30,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 2
-
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
- resolve deprecation warning and checkout warning for the code QL files
- add `name` variables to api pipeline jobs

Warnings from the GHA dashboard:
```
1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results. 
```
```
Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see https://github.com/actions/virtual-environments/issues/1816
```