### PR TITLE
Buildings API endpoints with partial info

### DIFF
--- a/api/buildings/serializers.py
+++ b/api/buildings/serializers.py
@@ -6,7 +6,19 @@ from .models import Building, Statistic
 class BuildingSerializer(serializers.ModelSerializer):
     class Meta:
         model = Building
-        exclude = ()  # TODO: restrict to the necessary fields if needed
+        fields = "__all__"
+
+
+class BuildingListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Building
+        fields = ("general_id", "risk_category", "lat", "lng")
+
+
+class BuildingSearchSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Building
+        fields = ("general_id", "lat", "lng", "address", "post_code")
 
 
 class StatisticSerializer(serializers.ModelSerializer):

--- a/api/buildings/views.py
+++ b/api/buildings/views.py
@@ -6,7 +6,12 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework import permissions
 from rest_framework.response import Response
 
-from .serializers import BuildingSerializer, StatisticSerializer
+from .serializers import (
+    BuildingSerializer,
+    BuildingListSerializer,
+    BuildingSearchSerializer,
+    StatisticSerializer,
+)
 from .models import Building, Statistic
 
 
@@ -16,8 +21,12 @@ class BuildingViewSet(viewsets.ModelViewSet):
     """
 
     queryset = Building.objects.all().order_by("-created_on")
-    serializer_class = BuildingSerializer
     lookup_field = "general_id"
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return BuildingListSerializer
+        return BuildingSerializer
 
 
 @api_view(["GET"])
@@ -33,7 +42,7 @@ def building_search(request):
         .order_by("-similarity")
     )
 
-    serializer = BuildingSerializer(buildings, many=True)
+    serializer = BuildingSearchSerializer(buildings, many=True)
 
     return Response(serializer.data)
 

--- a/api/tests/test_buildings_api.py
+++ b/api/tests/test_buildings_api.py
@@ -2,9 +2,24 @@ import pytest
 import random, string
 
 from buildings.models import Building
+from buildings.serializers import BuildingListSerializer
 from django.urls import reverse
 
 base_url = "/api/v1/buildings"
+
+
+@pytest.mark.django_db
+def test_building_list_get(basic_building_data, api_client):
+    for _ in range(3):
+        building_obj = Building.objects.create(**basic_building_data)
+
+    url = f"{base_url}/"
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    for building in response.data:
+        for key in building.keys():
+            assert key in BuildingListSerializer.Meta.fields
 
 
 @pytest.mark.django_db

--- a/client/src/components/HereMapInteractive/HereMapInteractive.js
+++ b/client/src/components/HereMapInteractive/HereMapInteractive.js
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
-import BuildingDetails from '../BuildingDetails';
+import BuildingDetailsFragment from '../../containers/building/BuildingDetailsFragment';
 import SearchResults from '../SearchResults';
 
 import { useGlobalContext } from '../../context';
@@ -56,10 +56,10 @@ const HereMapInteractive = (props) => {
           ref={mapRef}
           style={{ width: '100%', height: '400px', background: 'grey' }}
         >
-          <BuildingDetails
+          <BuildingDetailsFragment
             visible={isDrawerVisible}
             onClose={onHideBuilding}
-            details={buildingDetails}
+            incompleteDetails={buildingDetails}
           />
           <SearchResults onItemSelected={onSelectBuilding} />
         </div>

--- a/client/src/containers/building/BuildingDetailsFragment.js
+++ b/client/src/containers/building/BuildingDetailsFragment.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import BuildingDetails from '../../components/BuildingDetails';
+
+import config from '../../config';
+
+const { BUILDINGS_URL } = config;
+
+export default (props) => {
+  const { visible, onClose, incompleteDetails } = props;
+  const [state, setState] = React.useState({
+    completeDetails: {},
+  });
+
+  React.useEffect(() => {
+    if (incompleteDetails == null) return;
+
+    const buildingURL = `${BUILDINGS_URL}/${incompleteDetails.general_id}`;
+
+    fetch(buildingURL)
+      .then((res) => res.json())
+      .then((details) => {
+        setState(() => ({
+          completeDetails: details,
+        }));
+      })
+      .catch(() => {});
+  }, [incompleteDetails]);
+
+  return <BuildingDetails visible={visible} onClose={onClose} details={state.completeDetails} />;
+};


### PR DESCRIPTION
### What does it fix?
Listing and searching buildings return only part of the details.
The client loads full info on request. (see BuildingDetailsFragment)

Closes #573 

### How has it been tested?
Added unit tests. Manual testing on the frontend, the screenshots below.
![seismic1](https://user-images.githubusercontent.com/10727813/109488022-ac9ed580-7a8d-11eb-8e64-edb6fa132aae.png)
![Screenshot from 2021-03-01 13-00-28](https://user-images.githubusercontent.com/10727813/109488349-1fa84c00-7a8e-11eb-9f1e-3923733d59ca.png)


