### PR TITLE
fix publish_date referencing to server

### DIFF
--- a/api/blog/views.py
+++ b/api/blog/views.py
@@ -23,12 +23,6 @@ class PostViewSet(viewsets.ModelViewSet):
     """
 
     permissions_classes = (IsUserOrReadOnly,)
-    queryset = (
-        Post.objects.all()
-        .select_related("author")
-        .filter(published__lte=timezone.now(), is_visible=True)
-        .order_by("-published")
-    )
     serializer_class = PostSerializer
     lookup_field = "slug"
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
@@ -40,3 +34,11 @@ class PostViewSet(viewsets.ModelViewSet):
         "author__last_name",
     ]
     ordering_fields = ["created", "updated", "published"]
+
+    def get_queryset(self):
+        return (
+            Post.objects.all()
+            .select_related("author")
+            .filter(published__lte=timezone.localtime(), is_visible=True)
+            .order_by("-published")
+        )

--- a/api/seismic_site/settings.py
+++ b/api/seismic_site/settings.py
@@ -118,7 +118,7 @@ class Base(Configuration):
     # https://docs.djangoproject.com/en/2.2/topics/i18n/
 
     LANGUAGE_CODE = values.Value(default="en-us")
-    TIME_ZONE = "UTC"
+    TIME_ZONE = "Europe/Bucharest"
     USE_I18N = True
     USE_L10N = True
     USE_TZ = True


### PR DESCRIPTION

<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Fixes #549 

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->

Manual test:
1. add a post via admin interface with time and date set to NOW
2. check post api results
3. compare publish time with system time.
**Post shows up immediately** 
![image](https://user-images.githubusercontent.com/11949565/109662257-87849280-7b73-11eb-9532-6728c8819e95.png)

Django logs for two queries distinct in time:

`2021-03-02 16:10:08,988 (0.003) SELECT "blog_post"."id", "blog_post"."author_id", "blog_post"."title", "blog_post"."slug", "blog_post"."image", "blog_post"."text", "blog_post"."is_visible", "blog_post"."published", "blog_post"."created", "blog_post"."updated", "auth_user"."id", "auth_user"."password", "auth_user"."last_login", "auth_user"."is_superuser", "auth_user"."username", "auth_user"."first_name", "auth_user"."last_name", "auth_user"."email", "auth_user"."is_staff", "auth_user"."is_active", "auth_user"."date_joined" FROM "blog_post" INNER JOIN "auth_user" ON ("blog_post"."author_id" = "auth_user"."id") WHERE ("blog_post"."is_visible" = true AND "blog_post"."published" <= '2021-03-02T16:10:08.981586+02:00'::timestamptz) ORDER BY "blog_post"."published" DESC; args=(True, datetime.datetime(2021, 3, 2, 16, 10, 8, 981586, tzinfo=<DstTzInfo 'Europe/Bucharest' EET+2:00:00 STD>))
`

`2021-03-02 16:11:06,234 (0.002) SELECT "blog_post"."id", "blog_post"."author_id", "blog_post"."title", "blog_post"."slug", "blog_post"."image", "blog_post"."text", "blog_post"."is_visible", "blog_post"."published", "blog_post"."created", "blog_post"."updated", "auth_user"."id", "auth_user"."password", "auth_user"."last_login", "auth_user"."is_superuser", "auth_user"."username", "auth_user"."first_name", "auth_user"."last_name", "auth_user"."email", "auth_user"."is_staff", "auth_user"."is_active", "auth_user"."date_joined" FROM "blog_post" INNER JOIN "auth_user" ON ("blog_post"."author_id" = "auth_user"."id") WHERE ("blog_post"."is_visible" = true AND "blog_post"."published" <= '2021-03-02T16:11:06.230799+02:00'::timestamptz) ORDER BY "blog_post"."published" DESC; args=(True, datetime.datetime(2021, 3, 2, 16, 11, 6, 230799, tzinfo=<DstTzInfo 'Europe/Bucharest' EET+2:00:00 STD>))`

Now the current time is used as reference time in query. See issue comments to acknowledge how it was before fix. 
