### PR TITLE
feat: pagination for blog posts

### DIFF
--- a/api/blog/views.py
+++ b/api/blog/views.py
@@ -1,7 +1,7 @@
 from django.utils import timezone
 from .serializers import PostSerializer, TagSerializer
 from .permissions import IsUserOrReadOnly
-from rest_framework import viewsets, filters
+from rest_framework import viewsets, filters, pagination
 from taggit.models import Tag
 
 from .models import Post
@@ -18,6 +18,11 @@ class TagViewSet(viewsets.ModelViewSet):
     serializer_class = TagSerializer
 
 
+class PostsPagination(pagination.LimitOffsetPagination):
+    default_limit = 4
+    max_limit = 10
+
+
 class PostViewSet(viewsets.ModelViewSet):
     """
     API endpoint that lists blog posts
@@ -25,6 +30,7 @@ class PostViewSet(viewsets.ModelViewSet):
 
     permissions_classes = (IsUserOrReadOnly,)
     serializer_class = PostSerializer
+    pagination_class = PostsPagination
     lookup_field = "slug"
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = [

--- a/api/tests/test_blog_api.py
+++ b/api/tests/test_blog_api.py
@@ -1,6 +1,7 @@
 import pytest
 
 from blog.models import Post
+from blog.views import PostsPagination
 
 base_url = "/api/v1/posts"
 
@@ -41,3 +42,20 @@ def basic_post_data():
         "is_visible": True,
         "published": timezone.now(),
     }
+
+
+@pytest.mark.django_db
+def test_post_pagination(basic_post_data, api_client, test_user):
+    for i in range(PostsPagination.max_limit + 1):
+        basic_post_data["slug"] = str(i)
+        basic_post_data["author_id"] = test_user.id
+        Post.objects.create(**basic_post_data)
+
+    custom_limit = PostsPagination.default_limit // 2
+    custom_offset = PostsPagination.max_limit // 2
+    response = api_client.get(
+        f"{base_url}/?offset={custom_offset}&limit={custom_limit}"
+    )
+    assert response.status_code == 200
+    assert len(response.data["results"]) == custom_limit
+    assert response.data["results"][0]["slug"] == str(custom_offset)


### PR DESCRIPTION
### What does it fix?
Implements limit&offset pagination for posts endpoint.

Closes #643 
Closes #644 

### How has it been tested?
Automated test written.

### Note
Should be merged only after #644 is implemented too as the response format has changed and it would break the frontend.

I could do the necessary frontend change tomorrow and merge everything in one PR. 