### PR TITLE
Fixes #743: share buttons will hold the link of current post

### DIFF
--- a/client/src/components/Sharing/index.js
+++ b/client/src/components/Sharing/index.js
@@ -7,9 +7,9 @@ import twitterLogo from '../../images/twitter.svg';
 import whatsappLogo from '../../images/whatsapp.svg';
 import telegramLogo from '../../images/telegram.svg';
 
-const URL = 'https://seismic-risc.now.sh';
-
 function Sharing() {
+  const URL = window.location.href;
+
   const copyToClipboard = useCallback(() => {
     navigator.clipboard.writeText(URL);
   }, []);


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #743 

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->
I changed URL from using `https://seismic-risc.now.sh` to `window.location.href` so that it will point to the current post that user's at. I tested on my local and everything seem to work just fine.
