### PR TITLE
[Issue 774] - Prevent wheel default event

### DIFF
--- a/client/src/components/HereMapInteractive/index.js
+++ b/client/src/components/HereMapInteractive/index.js
@@ -30,7 +30,6 @@ const HereMapInteractive = (props) => {
 
   const showSearchResults = buildingDetails;
   const showRightPanel = showSearchResults || buildingDetails;
-  
   mapRef?.current?.addEventListener('wheel', (e) => e.preventDefault());
 
   return (

--- a/client/src/components/HereMapInteractive/index.js
+++ b/client/src/components/HereMapInteractive/index.js
@@ -30,6 +30,8 @@ const HereMapInteractive = (props) => {
 
   const showSearchResults = buildingDetails;
   const showRightPanel = showSearchResults || buildingDetails;
+  
+  mapRef?.current?.addEventListener('wheel', (e) => e.preventDefault());
 
   return (
     <div style={{ height: '422px', position: 'relative' }}>


### PR DESCRIPTION
Prevent mouse wheel default event on the map container.

### What does it fix?

Closes #774 

Prevents mouse wheel default event on the map container.

### How has it been tested?

Tested it on Safari, Chrome and Brave browsers.