### PR TITLE
[Issue 772] - Remove forceRenderOnLocaleChange

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -26,7 +26,7 @@ const App = () => {
   }, []);
 
   return (
-    <I18nProvider i18n={i18n} forceRenderOnLocaleChange={false}>
+    <I18nProvider i18n={i18n}>
       <Router>
         <ScrollToTop />
         <Switch>


### PR DESCRIPTION
### What does it fix?

Closes #772 

Removing forceRenderOnLocaleChange attribute from I18nProvider.

### How has it been tested?

Tested it on Safari, Chrome and Brave browsers, on all pages.
