### PR TITLE
[Issue 742] Pass language parameter to hCaptcha fragment

### DIFF
--- a/client/src/containers/add-building/FormFragment.js
+++ b/client/src/containers/add-building/FormFragment.js
@@ -7,6 +7,7 @@ import PinDrop from '../../images/pin_drop.svg';
 
 import config from '../../config';
 import HereMapAddBuilding from '../../components/HereMapAddBuilding';
+import { useGlobalContext } from '../../context';
 
 const { Title } = Typography;
 
@@ -33,8 +34,10 @@ const FormFragment = ({ form }) => {
   });
   const [mapSearchText, setMapSearchText] = useState(undefined);
   const [coordinates, setCoordinates] = useState(undefined);
+  const [language, setLanguage] = useState(undefined);
   const { getFieldDecorator } = form;
   const fields = form.getFieldsValue();
+  const { currentLanguage } = useGlobalContext();
 
   const onFinish = (e) => {
     e.preventDefault();
@@ -106,6 +109,10 @@ const FormFragment = ({ form }) => {
 
     getRiskCategories();
   }, []);
+
+  useEffect(() => {
+    setLanguage(currentLanguage);
+  }, [currentLanguage]);
 
   if (state.loading) {
     return (
@@ -198,7 +205,14 @@ const FormFragment = ({ form }) => {
       <Form.Item label={<Trans>Captcha</Trans>}>
         {getFieldDecorator('captcha', {
           rules: [{ required: true, message: <EmptyFieldMessage /> }],
-        })(<HCaptcha sitekey={CAPTCHA_API_KEY} onVerify={handleVerifyCaptcha} />)}
+        })(
+          <HCaptcha
+            sitekey={CAPTCHA_API_KEY}
+            onVerify={handleVerifyCaptcha}
+            hl={language}
+            languageOverride={language}
+          />,
+        )}
       </Form.Item>
       <Form.Item>
         <Button type="primary" htmlType="submit" disabled={state.requestError}>


### PR DESCRIPTION
### What does it fix?

Closes #742 

Passing current language of the app to the hCaptcha fragment. 
The “hl” attribute only sets the language of the hCaptcha at the first render of the page. 
When the language is changed using the language dropdown, the hCaptcha will re-render only if the languageOverride attribute is present and with the value that it contains.

### How has it been tested?

Tested manually on Chrome, Safari and Brave browsers.
