### PR TITLE
No Issue | Prevent wheel zoom on map

### DIFF
--- a/client/src/components/HereMapInteractive/index.js
+++ b/client/src/components/HereMapInteractive/index.js
@@ -30,7 +30,6 @@ const HereMapInteractive = (props) => {
 
   const showSearchResults = buildingDetails;
   const showRightPanel = showSearchResults || buildingDetails;
-  // mapRef?.current?.addEventListener('wheel', (e) => e.preventDefault());
 
   return (
     <div style={{ height: '422px', position: 'relative' }}>

--- a/client/src/components/HereMapInteractive/index.js
+++ b/client/src/components/HereMapInteractive/index.js
@@ -30,7 +30,7 @@ const HereMapInteractive = (props) => {
 
   const showSearchResults = buildingDetails;
   const showRightPanel = showSearchResults || buildingDetails;
-  mapRef?.current?.addEventListener('wheel', (e) => e.preventDefault());
+  // mapRef?.current?.addEventListener('wheel', (e) => e.preventDefault());
 
   return (
     <div style={{ height: '422px', position: 'relative' }}>

--- a/client/src/hooks/map/useCreateMap.js
+++ b/client/src/hooks/map/useCreateMap.js
@@ -24,8 +24,9 @@ export function useCreateMap(mapRef) {
     });
 
     const events = new H.mapevents.MapEvents(hMap);
-    // eslint-disable-next-line no-unused-vars
     const behavior = new H.mapevents.Behavior(events);
+    behavior.disable(H.mapevents.Behavior.Feature.WHEEL_ZOOM);
+
     // eslint-disable-next-line no-unused-vars, new-cap
     const ui = new H.ui.UI.createDefault(hMap, layer);
 
@@ -41,8 +42,24 @@ export function useCreateMap(mapRef) {
       }
     };
 
+    const onMapDragStartHandler = (event) => {
+      if (event.originalEvent.pointerType === 'mouse') return;
+
+      if (event.targetPointers.length === 1) {
+        behavior.disable(H.mapevents.Behavior.Feature.PANNING);
+      }
+    };
+
+    const onMapDragEndHandler = (event) => {
+      if (event.originalEvent.pointerType === 'mouse') return;
+
+      behavior.enable(H.mapevents.Behavior.Feature.PANNING);
+    };
+
     mapEngine.addEventListener('render', onMapRendered);
     window.addEventListener('resize', onResizeWindow);
+    hMap.addEventListener('dragstart', onMapDragStartHandler);
+    hMap.addEventListener('dragend', onMapDragEndHandler);
 
     setMap(hMap);
 


### PR DESCRIPTION
disable map panning on mobile if only one touch

<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

* Disabled wheel zoom on map.
* On desktop user can zoom using the UI buttons.
* On mobile panning is disabled if only one finger is used. Zooming and panning is enabled if two fingers are used.

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->
Manually.

![map_zoom_desktop](https://user-images.githubusercontent.com/22684808/150697837-7dd3ddc2-3621-4f41-aa6a-a8ad98d99781.gif)

![map_zoom_mobile](https://user-images.githubusercontent.com/22684808/150697897-b1af791e-180e-4649-bb2a-4203e8ea379b.gif)