### PR TITLE
resolves #919

### DIFF
--- a/client/src/hooks/map/useDecoratedClusteredMap.js
+++ b/client/src/hooks/map/useDecoratedClusteredMap.js
@@ -85,7 +85,6 @@ export default function useDecoratedClusteredMap(currentMap, points) {
     if (!currentMap || !zoom) {
       return;
     }
-    currentMap.getViewPort().resize();
     if (selectedMarker) {
       const position = { ...selectedMarker.getData().getPosition() };
       currentMap.getViewModel().setLookAtData({ position, zoom }, true);


### PR DESCRIPTION
The bug seems to be caused when `currentMap.getViewPort().resize()` is called, which happens twice.  The map zoom happens correctly once this call is removed. 